### PR TITLE
devices: fix play/pause order on tanix-tx3-mini

### DIFF
--- a/devices/tanix-tx3-mini.dtso
+++ b/devices/tanix-tx3-mini.dtso
@@ -80,11 +80,11 @@
 				};
 				led@4,3 {
 					reg = <4 3>;
-					function = "play";
+					function = "pause";
 				};
 				led@4,2 {
 					reg = <4 2>;
-					function = "pause";
+					function = "play";
 				};
 				led@4,4 {
 					reg = <4 4>;


### PR DESCRIPTION
These are incorrect in the original vfd confs so this gets replicated each time the .dtso files are regenerated.