### PR TITLE
display-service: make icon LED triggers configurable

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -60,6 +60,7 @@ service-install:
 	modprobe tm16xx
 	cp display-service /usr/sbin/
 	cp display.service /lib/systemd/system/
+	[ -f /etc/default/display-service ] || cp display-service.conf /etc/default/display-service
 	systemctl daemon-reload
 	systemctl enable display
 	systemctl restart display

--- a/README.md
+++ b/README.md
@@ -87,7 +87,9 @@ Depending on the icons configured for the auxiliary display, additional led trig
 | Time seperator blink | `colon` | `timer` | `ledtrig_timer` | `CONFIG_LEDS_TRIGGER_TIMER=y` or `m` |
 | Network activity | `lan`, `wlan`, `bluetooth` | `netdev` | `ledtrig_netdev` | `CONFIG_LEDS_TRIGGER_NETDEV=y` or `m` |
 | USB activity | `usb` | `usbport` | `ledtrig-usbport` | `CONFIG_USB_LEDS_TRIGGER_USBPORT=y` or `m` |
-| SD/MMC activity | `sd` | `mmc0` | `mmc_core` | `CONFIG_MMC=y` or `m` |
+| SD/MMC activity | `sd` | `mmc0` (board specific, see note) | `mmc_core` | `CONFIG_MMC=y` or `m` |
+
+The `sd` icon defaults to the `mmc0` host, but mmc host numbering is board specific. On many Amlogic boxes (for example S905X2 / X96 Max) `mmc0` is the SDIO WiFi controller while the SD slot and eMMC are `mmc1` and `mmc2`, so the icon ends up following WiFi traffic and looks like it blinks at random. Override it (and the other icon triggers) in `/etc/default/display-service` without editing the script; see [Customize display service](#customize-display-service).
 
 ## Download
 ```sh
@@ -207,7 +209,24 @@ display-service -t "{your_message}"
 ```
 
 ## Customize display service
-Just edit the shell script at `/usr/sbin/display-service`
+For the common case of changing which activity each status icon follows, edit `/etc/default/display-service` instead of the script. It is sourced by the daemon at startup and lets you override the icon LED triggers and the network devices they watch:
+
+```sh
+# /etc/default/display-service
+
+# point the SD icon at the real card slot / eMMC instead of mmc0
+TRIGGER_SDCARD=mmc2
+
+# follow a different wired interface
+DEV_LAN=end0
+
+# leave an icon off (empty value)
+TRIGGER_USB=
+```
+
+Apply changes with `systemctl restart display`. List the triggers a given icon supports with `cat /sys/class/leds/display::sd/trigger`. The defaults reproduce the previous built-in behaviour, so an install without this file is unchanged.
+
+For anything beyond the icon triggers, edit the shell script at `/usr/sbin/display-service`.
 
 ## Customize display from shell
 ```sh

--- a/display-service
+++ b/display-service
@@ -166,6 +166,11 @@ configure_trigger() {
 	module_name="$4"
 	trigger_path="$led_path/trigger"
 
+	if [ -z "$trigger_name" ]; then
+		log_info "$led_name LED trigger disabled (empty), leaving it off"
+		return 1
+	fi
+
 	if [ ! -d "$led_path" ]; then
 		log_info "$led_name LED not found"
 		return 1
@@ -207,32 +212,32 @@ daemon_init() {
 	display_clear
 	display_on
 
-	if configure_trigger "USB" "$LED_USB" "usbport" "ledtrig-usbport"; then
+	if configure_trigger "USB" "$LED_USB" "$TRIGGER_USB" "ledtrig-usbport"; then
 		for port in "$LED_USB"/ports/*; do
 			[ -f "$port" ] && echo 1 > "$port" 2>/dev/null || log_warn "Failed to enable USB port: $port"
 		done
 	fi
 
-	if configure_trigger "LAN" "$LED_LAN" "netdev" "ledtrig_netdev"; then
-		echo eth0 > "$LED_LAN/device_name" 2>/dev/null || log_warn "Failed to set LAN device name"
+	if configure_trigger "LAN" "$LED_LAN" "$TRIGGER_LAN" "ledtrig_netdev"; then
+		echo "$DEV_LAN" > "$LED_LAN/device_name" 2>/dev/null || log_warn "Failed to set LAN device name"
 		echo 1 > "$LED_LAN/link" 2>/dev/null || log_warn "Failed to enable LAN link monitoring"
 	fi
 
-	if configure_trigger "WiFi" "$LED_WIFI" "netdev" "ledtrig_netdev"; then
-		echo wlan0 > "$LED_WIFI/device_name" 2>/dev/null || log_warn "Failed to set WiFi device name"
+	if configure_trigger "WiFi" "$LED_WIFI" "$TRIGGER_WIFI" "ledtrig_netdev"; then
+		echo "$DEV_WIFI" > "$LED_WIFI/device_name" 2>/dev/null || log_warn "Failed to set WiFi device name"
 		echo 1 > "$LED_WIFI/link" 2>/dev/null || log_warn "Failed to enable WiFi link monitoring"
 	fi
 
-	if configure_trigger "Bluetooth" "$LED_BLUETOOTH" "netdev" "ledtrig_netdev"; then
-		echo hci0 > "$LED_BLUETOOTH/device_name" 2>/dev/null || log_warn "Failed to set Bluetooth device name"
+	if configure_trigger "Bluetooth" "$LED_BLUETOOTH" "$TRIGGER_BLUETOOTH" "ledtrig_netdev"; then
+		echo "$DEV_BLUETOOTH" > "$LED_BLUETOOTH/device_name" 2>/dev/null || log_warn "Failed to set Bluetooth device name"
 		echo 1 > "$LED_BLUETOOTH/link" 2>/dev/null || log_warn "Failed to enable Bluetooth link monitoring"
 	fi
 
-	configure_trigger "SD Card" "$LED_SDCARD" "mmc0" "mmc_core"
+	configure_trigger "SD Card" "$LED_SDCARD" "$TRIGGER_SDCARD" "mmc_core"
 }
 
 daemon_time_start() {
-	configure_trigger "Time Colon" "$LED_COLON" "timer" "ledtrig_timer"
+	configure_trigger "Time Colon" "$LED_COLON" "$TRIGGER_COLON" "ledtrig_timer"
 	daemon_time_update &
 	TIME_PID=$!
 	log_info "Time display started with PID $TIME_PID"
@@ -374,6 +379,25 @@ else
 	LED_BLUETOOTH="$DISPLAY_PATH::bluetooth"
 	LED_SDCARD="$DISPLAY_PATH::sd"
 	LED_COLON="$DISPLAY_PATH::colon"
+
+	# Optional per-device overrides for the icon LED triggers and the
+	# network devices the activity icons follow. Sourced as POSIX sh; see
+	# the shipped display-service.conf for what each setting does.
+	DISPLAY_SERVICE_CONF="${DISPLAY_SERVICE_CONF:-/etc/default/display-service}"
+	[ -r "$DISPLAY_SERVICE_CONF" ] && . "$DISPLAY_SERVICE_CONF"
+
+	# Defaults below reproduce the previous built-in behaviour, so an
+	# install without a config file behaves exactly as before. Set any
+	# trigger to an empty value to leave that icon off.
+	TRIGGER_USB="${TRIGGER_USB-usbport}"
+	TRIGGER_LAN="${TRIGGER_LAN-netdev}"
+	TRIGGER_WIFI="${TRIGGER_WIFI-netdev}"
+	TRIGGER_BLUETOOTH="${TRIGGER_BLUETOOTH-netdev}"
+	TRIGGER_SDCARD="${TRIGGER_SDCARD-mmc0}"
+	TRIGGER_COLON="${TRIGGER_COLON-timer}"
+	DEV_LAN="${DEV_LAN-eth0}"
+	DEV_WIFI="${DEV_WIFI-wlan0}"
+	DEV_BLUETOOTH="${DEV_BLUETOOTH-hci0}"
 
 	daemon_init
 	trap daemon_stop HUP TERM QUIT INT

--- a/display-service.conf
+++ b/display-service.conf
@@ -1,0 +1,40 @@
+# Configuration for display-service (TM16xx LED panel daemon).
+#
+# Installed to /etc/default/display-service and sourced as POSIX sh.
+# Uncomment and edit what you need, then apply with:
+#   systemctl restart display
+#
+# Each status icon can follow a kernel LED "trigger" (an activity source).
+# See the triggers your kernel offers for a given icon with, e.g.:
+#   cat /sys/class/leds/display::sd/trigger
+# Set a value to an empty string to leave that icon off.
+
+# USB port activity
+#TRIGGER_USB=usbport
+
+# Wired network: link/activity for DEV_LAN
+#TRIGGER_LAN=netdev
+#DEV_LAN=eth0
+
+# Wireless network: link/activity for DEV_WIFI
+#TRIGGER_WIFI=netdev
+#DEV_WIFI=wlan0
+
+# Bluetooth: link/activity for DEV_BLUETOOTH
+#TRIGGER_BLUETOOTH=netdev
+#DEV_BLUETOOTH=hci0
+
+# SD / storage activity.
+#
+# The built-in default is mmc0, but mmc host numbering is board specific.
+# On many Amlogic boxes (for example S905X2 / X96 Max) mmc0 is the SDIO
+# WiFi interface, while the SD card slot and the eMMC are mmc1 and mmc2.
+# In that case the "SD" icon follows WiFi traffic and looks like it blinks
+# at random, even with no card inserted. Find which host is which with:
+#   ls -l /sys/class/mmc_host/*/   # match controllers to mmc0/mmc1/mmc2
+#   lsblk                          # see where the rootfs/card actually live
+# then point the icon at the host you want, or set it empty to disable it.
+#TRIGGER_SDCARD=mmc0
+
+# Time separator colon blink
+#TRIGGER_COLON=timer


### PR DESCRIPTION
## What

`display-service` hardcodes the status-icon LED triggers (USB, LAN, WiFi, Bluetooth, SD, colon) and the network devices the activity icons watch. This adds an optional `/etc/default/display-service` that can override them, with defaults that match today's behaviour.

## Why

The `sd` icon is wired to the `mmc0` host. mmc host numbering is board specific, and on Amlogic S905X2 boxes (X96 Max and alike) `mmc0` is the SDIO WiFi controller, not a card slot. The icon then follows WiFi traffic and looks like it blinks at random, even with no card inserted and Ethernet as the active link. The same hardcoding makes it awkward to watch a different wired interface (say `end0`), point the icon at the eMMC, or turn an icon off.

The README's current advice for any of this is to edit `/usr/sbin/display-service`, which a package update overwrites.

## What changed

- `display-service` sources an optional `/etc/default/display-service` (POSIX sh) and reads triggers and device names from variables. Defaults reproduce the previous behaviour, so installs without the file are unchanged. An empty value leaves an icon off.
- Added `display-service.conf`, a documented sample, installed to `/etc/default/display-service` by `make service-install` without clobbering an existing one.
- README: documented the config file and flagged that the `mmc0` default is board specific.

## Tested

X96 Max (S905X2), ophub Armbian, kernel 6.18.33. With `TRIGGER_SDCARD=mmc2` the icon tracks real eMMC activity; with an empty value it stays off; defaults behave as before. `sh -n` is clean.

## Possible follow-up (not in this PR)

The default could autodetect the correct mmc host rather than assume `mmc0`, for example by picking the host whose `type` reads `SD` under `/sys/class/mmc_host/*/*/type` and falling back to the current default.
